### PR TITLE
Add alerting provisioning with Discord webhook

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 group = "it.renvins"
-version = "0.1.2-SNAPSHOT"
+version = "0.1.3-SNAPSHOT"
 
 repositories {
     mavenCentral()

--- a/infra/grafana/provisioning/alerting/contact_policy.yml
+++ b/infra/grafana/provisioning/alerting/contact_policy.yml
@@ -1,0 +1,7 @@
+apiVersion: 1
+policies:
+  - orgId: 1
+    receiver: Discord contact point
+    group_wait: 0s # Wait for 0 seconds before sending the first notification
+    group_interval: 30s # Wait for 30 seconds before sending notifications about changes
+    repeat_interval: 3m # Repeat same notifications about every 3 minutes

--- a/infra/grafana/provisioning/alerting/discord_contact.yml
+++ b/infra/grafana/provisioning/alerting/discord_contact.yml
@@ -1,0 +1,13 @@
+apiVersion: 1
+contactPoints:
+  - orgId: 1
+    name: Discord contact point
+    receivers:
+      - uid: deiz0m4w2afpcb
+        type: discord
+        settings:
+          message: '{{ template "discord.default.message" . }}'
+          title: '{{ template "default.title" . }}'
+          url: https://discord.com/api/webhooks/1359937944529408100/nufab_o-rZpRj2RApWzRnpl5D_6w-cGu2w5gv3ksV0RcM2eVC2lvotJqNTGtDbNBDGsO # The Discord webhook URL
+          use_discord_username: false
+        disableResolveMessage: false

--- a/infra/grafana/provisioning/alerting/metrics.yml
+++ b/infra/grafana/provisioning/alerting/metrics.yml
@@ -50,7 +50,7 @@ groups:
               conditions:
                 - evaluator:
                     params:
-                      - 21
+                      - 18
                     type: lt
                   operator:
                     type: and

--- a/infra/grafana/provisioning/alerting/metrics.yml
+++ b/infra/grafana/provisioning/alerting/metrics.yml
@@ -1,0 +1,76 @@
+apiVersion: 1
+groups:
+  - orgId: 1
+    name: Metrics evaluation
+    folder: Metrics alerts
+    interval: 10s
+    rules:
+      - uid: ceiz0fk56qmtcd
+        title: Low TPS
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 600
+              to: 0
+            datasourceUid: P5697886F9CA74929
+            model:
+              intervalMs: 1000
+              maxDataPoints: 43200
+              query: "from(bucket: \"metrics_db\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r._measurement == \"minecraft_stats\")\r\n  |> filter(fn: (r) => r._field == \"tps_1m\")\r\n  |> filter(fn: (r) => r.server == \"bed1\")\r\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\r\n  |> yield(name: \"mean_tps_1m\")"
+              refId: A
+          - refId: B
+            datasourceUid: __expr__
+            model:
+              conditions:
+                - evaluator:
+                    params: []
+                    type: gt
+                  operator:
+                    type: and
+                  query:
+                    params:
+                      - B
+                  reducer:
+                    params: []
+                    type: last
+                  type: query
+              datasource:
+                type: __expr__
+                uid: __expr__
+              expression: A
+              intervalMs: 1000
+              maxDataPoints: 43200
+              reducer: last
+              refId: B
+              type: reduce
+          - refId: C
+            datasourceUid: __expr__
+            model:
+              conditions:
+                - evaluator:
+                    params:
+                      - 21
+                    type: lt
+                  operator:
+                    type: and
+                  query:
+                    params:
+                      - C
+                  reducer:
+                    params: []
+                    type: last
+                  type: query
+              datasource:
+                type: __expr__
+                uid: __expr__
+              expression: B
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: C
+              type: threshold
+        noDataState: NoData
+        execErrState: Error
+        isPaused: false
+        notification_settings:
+          receiver: Discord contact point


### PR DESCRIPTION
Implemented default provisioning on docker compose start to receive alerts when TPS are below 18. It's just an example, implement other metrics on your own