### PR TITLE
fix: Moving from ticks to ms to better handle all server environments

### DIFF
--- a/bukkit/src/main/java/it/renvins/serverpulse/bukkit/scheduler/BukkitTaskScheduler.java
+++ b/bukkit/src/main/java/it/renvins/serverpulse/bukkit/scheduler/BukkitTaskScheduler.java
@@ -18,7 +18,9 @@ public class BukkitTaskScheduler implements TaskScheduler {
     }
 
     @Override
-    public void runTaskTimer(Runnable task, long delayTicks, long periodTicks) {
+    public void runTaskTimer(Runnable task, long delayMs, long periodMs) {
+        long delayTicks = delayMs / 50;
+        long periodTicks = periodMs / 50;
         plugin.getServer().getScheduler().runTaskTimer(plugin, task, delayTicks, periodTicks);
     }
 
@@ -28,7 +30,9 @@ public class BukkitTaskScheduler implements TaskScheduler {
     }
 
     @Override
-    public Task runTaskTimerAsync(Runnable task, long delayTicks, long periodTicks) {
+    public Task runTaskTimerAsync(Runnable task, long delayMs, long periodMs) {
+        long delayTicks = delayMs / 50;
+        long periodTicks = periodMs / 50;
         return new BukkitTaskWrapper(plugin.getServer().getScheduler().runTaskTimerAsynchronously(plugin, task, delayTicks, periodTicks));
     }
 }

--- a/bungeecord/src/main/java/it/renvins/serverpulse/bungeecord/scheduler/BungeeCordTaskScheduler.java
+++ b/bungeecord/src/main/java/it/renvins/serverpulse/bungeecord/scheduler/BungeeCordTaskScheduler.java
@@ -18,10 +18,7 @@ public class BungeeCordTaskScheduler implements TaskScheduler {
     }
 
     @Override
-    public Task runTaskTimerAsync(Runnable task, long delayTicks, long periodTicks) {
-        long delayMs = delayTicks * 50L; // 20 ticks/second = 50ms per tick
-        long periodMs = periodTicks * 50L;
-
+    public Task runTaskTimerAsync(Runnable task, long delayMs, long periodMs) {
         return new BungeeCordTaskWrapper(
                 plugin.getProxy().getScheduler().schedule(plugin, task, delayMs, periodMs, TimeUnit.MILLISECONDS));
     }

--- a/common/src/main/java/it/renvins/serverpulse/common/DatabaseService.java
+++ b/common/src/main/java/it/renvins/serverpulse/common/DatabaseService.java
@@ -29,7 +29,7 @@ public class DatabaseService implements IDatabaseService {
     private volatile Task retryTask; // volatile for visibility across threads
 
     private final int MAX_RETRIES = 5;
-    private final long RETRY_DELAY_TICKS = 20L * 30L; // 30 seconds
+    private final long RETRY_DELAY_MS = 30000L; // 30 seconds
 
     // Use volatile as this is read/written by different threads
     private volatile boolean isConnected = false;
@@ -193,7 +193,7 @@ public class DatabaseService implements IDatabaseService {
 
             logger.info("Retrying InfluxDB connection... Attempt " + retryCount + "/" + MAX_RETRIES);
             connect(); // Note: connect() will handle setting isConnected flag and potentially stopping the task if successful.
-        }, RETRY_DELAY_TICKS, RETRY_DELAY_TICKS); // Start after delay, repeat at delay
+        }, RETRY_DELAY_MS, RETRY_DELAY_MS); // Start after delay, repeat at delay
     }
 
 

--- a/common/src/main/java/it/renvins/serverpulse/common/scheduler/TaskScheduler.java
+++ b/common/src/main/java/it/renvins/serverpulse/common/scheduler/TaskScheduler.java
@@ -18,9 +18,11 @@ public interface TaskScheduler {
      * Runs a task timer synchronously on the main thread.
      *
      * @param task The task to run
+     * @param delayMs Delay in milliseconds before first executing
+     * @param periodMs Period in milliseconds between executions
      * @throws UnsupportedOperationException if the implementation does not support synchronous task execution
      */
-    default void runTaskTimer(Runnable task, long delayTicks, long periodTicks) {
+    default void runTaskTimer(Runnable task, long delayMs, long periodMs) {
         throw new UnsupportedOperationException("Synchronous task timer execution is not supported.");
     }
 
@@ -35,9 +37,11 @@ public interface TaskScheduler {
      * Runs a task timer asynchronously on a separate thread.
      *
      * @param task The task to run
+     * @param delayMs Delay in milliseconds before first executing
+     * @param periodMs Period in milliseconds between executions
      * @return A Task object representing the task
      */
-    Task runTaskTimerAsync(Runnable task, long delayTicks, long periodTicks);
+    Task runTaskTimerAsync(Runnable task, long delayMs, long periodMs);
 
 
     /**

--- a/fabric/src/main/java/it/renvins/serverpulse/fabric/task/FabricScheduler.java
+++ b/fabric/src/main/java/it/renvins/serverpulse/fabric/task/FabricScheduler.java
@@ -25,7 +25,9 @@ public class FabricScheduler implements TaskScheduler {
     }
 
     @Override
-    public void runTaskTimer(Runnable task, long delayTicks, long periodTicks) {
+    public void runTaskTimer(Runnable task, long delayMs, long periodMs) {
+        long delayTicks = delayMs / 50;
+        long periodTicks = periodMs / 50;
         FabricTask fabricTask = new FabricTask(task, true, delayTicks, periodTicks);
         tasks.add(fabricTask);
     }
@@ -41,7 +43,10 @@ public class FabricScheduler implements TaskScheduler {
     }
 
     @Override
-    public Task runTaskTimerAsync(Runnable task, long delayTicks, long periodTicks) {
+    public Task runTaskTimerAsync(Runnable task, long delayMs, long periodMs) {
+        long delayTicks = delayMs / 50;
+        long periodTicks = periodMs / 50;
+
         FabricTask fabricTask = new FabricTask(() -> CompletableFuture.runAsync(task).exceptionally(
                 throwable -> {
                     ServerPulseFabric.LOGGER.log(java.util.logging.Level.SEVERE, "An error occurred while executing task!", throwable);

--- a/velocity/src/main/java/it/renvins/serverpulse/velocity/ServerPulseVelocity.java
+++ b/velocity/src/main/java/it/renvins/serverpulse/velocity/ServerPulseVelocity.java
@@ -94,8 +94,8 @@ public class ServerPulseVelocity {
         }
         metricsService.load();
 
-        long intervalTicks = config.getConfig().getLong("metrics.interval", 5) * 20L;
-        scheduler.runTaskTimerAsync(metricsService::collectAndSendMetrics, 0L, intervalTicks);
+        long intervalMs = config.getConfig().getLong("metrics.interval", 5) * 1000L;
+        scheduler.runTaskTimerAsync(metricsService::collectAndSendMetrics, 0L, intervalMs);
 
         CommandMeta meta = server.getCommandManager().metaBuilder("serverpulsevelocity")
                 .plugin(this).aliases("spv").build();

--- a/velocity/src/main/java/it/renvins/serverpulse/velocity/scheduler/VelocityTaskScheduler.java
+++ b/velocity/src/main/java/it/renvins/serverpulse/velocity/scheduler/VelocityTaskScheduler.java
@@ -18,10 +18,10 @@ public class VelocityTaskScheduler implements TaskScheduler {
     }
 
     @Override
-    public Task runTaskTimerAsync(Runnable task, long delayTicks, long periodTicks) {
+    public Task runTaskTimerAsync(Runnable task, long delayMs, long periodMs) {
         return new VelocityTaskWrapper(plugin.getServer().getScheduler().buildTask(plugin, task)
-                        .delay(delayTicks / 20, TimeUnit.SECONDS)
-                        .repeat(periodTicks / 20, TimeUnit.SECONDS)
+                        .delay(delayMs, TimeUnit.MILLISECONDS)
+                        .repeat(periodMs, TimeUnit.MILLISECONDS)
                         .schedule());
     }
 }


### PR DESCRIPTION
### **Description**
This PR refactors the `TaskScheduler` abstraction to use milliseconds (`long delayMs`, `long periodMs`) instead of ticks across the entire project. This change addresses a critical bug in the Velocity implementation where tasks were running instantly due to integer division errors.

### **Key Changes**
*   **Fixed Velocity Scheduling Bug:**
    *   *Problem:* The Velocity scheduler previously converted ticks to seconds using integer division (`ticks / 20`). If a delay was less than 20 ticks (1 second), the result was `0`, causing tasks to run immediately in a tight loop.
    *   *Solution:* The scheduler now accepts milliseconds directly and passes them to the Velocity API using `TimeUnit.MILLISECONDS`.

*   **Standardized Time Units:**
    *   The `TaskScheduler` interface now enforces **milliseconds** as the standard unit of time. This removes ambiguity between "game ticks" (20/sec) and real-time, which is crucial for proxy platforms (Velocity/BungeeCord) that do not operate on a standard game loop.

*   **Platform Implementation Updates:**
    *   **Velocity & BungeeCord:** Now use their native millisecond/TimeUnit support without unnecessary conversions.
    *   **Bukkit & Fabric:** Now accept milliseconds and convert them back to server ticks (`ms / 50`) for compatibility with their internal schedulers.

*   **Service Updates:**
    *   `DatabaseService` now uses a clear `RETRY_DELAY_MS = 30000L` constant instead of calculating ticks, ensuring consistent retry behavior across all platforms.